### PR TITLE
fix: context file is now created inside of tests correctly

### DIFF
--- a/cli/example.py
+++ b/cli/example.py
@@ -4,6 +4,7 @@ TEST_SRC_FILE = os.path.dirname(__file__) + '/../init_example/test_fizzbuzz.py'
 TEST_DST_ROOT = './tests'
 
 CONTEXT_SRC_FILE = os.path.dirname(__file__) + '/../init_example/context.py'
+CONTEXT_SRC_ROOT = './tests'
 
 SRC_FILE = os.path.dirname(__file__) + '/../init_example/fizzbuzz.py'
 DST_ROOT = '.'
@@ -31,10 +32,10 @@ def create_fizzbuzz_test_file():
     if not os.path.isfile('tests/test_logic.py'):
         shutil.copy(TEST_SRC_FILE, TEST_DST_ROOT)
 
+def create_fizzbuzz_context_file():
+    if not os.path.isfile('tests/context.py'):
+        shutil.copy(CONTEXT_SRC_FILE, CONTEXT_SRC_ROOT)
+
 def create_fizzbuzz_file():
     if not os.path.isfile('logic.py'):
         shutil.copy(SRC_FILE, DST_ROOT)
-
-def create_fizzbuzz_context_file():
-    if not os.path.isfile('context.py'):
-        shutil.copy(CONTEXT_SRC_FILE, TEST_DST_ROOT)

--- a/cli/main.py
+++ b/cli/main.py
@@ -8,8 +8,7 @@ from .test import test
 from runner import run
 
 CONTEXT_SRC_FILE = os.path.dirname(__file__) + '/../init/context.py'
-# need to know which path
-TEST_DST_ROOT = '/tests'
+TEST_DST_ROOT = './tests'
 
 @click.group(
     invoke_without_command=True,
@@ -27,9 +26,12 @@ TEST_DST_ROOT = '/tests'
     is_flag=True)
 
 def cli(ctx, init):
+
     # --init
     if ctx.invoked_subcommand is None and init:
-        init_folder_creation()
+        create_test_dir()
+        create_context_file()
+
     # --run tests
     elif ctx.invoked_subcommand is None:
         run()
@@ -42,11 +44,13 @@ cli.add_command(about)
 cli.add_command(test)
 cli.add_command(example)
 
-# --init cli test dir creation
-def init_folder_creation():
+def create_test_dir():
     if not os.path.exists('tests'):
         os.makedirs('tests')
-        shutil.copy(CONTEXT_SRC_FILE, TEST_DST_ROOT)
-        click.echo('    created  test/')
+        click.echo('\t\tcreated\ttest/')
     else:
-        click.echo('    exists   test/')
+        click.echo('\t\texists\ttest/')
+
+def create_context_file():
+    if not os.path.isfile('tests/context.py'):
+        shutil.copy(CONTEXT_SRC_FILE, TEST_DST_ROOT)


### PR DESCRIPTION
Fixed a bug that cause context file not to be created in each test folder.